### PR TITLE
Fix variable scope in ElasticSearchCall exec method.

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -1,6 +1,7 @@
 var events = require('events'),
-http = require('http');
-https = require('https');
+http = require('http'),
+https = require('https'),
+util = require('util');
 
 
 module.exports = ElasticSearchCall;
@@ -12,20 +13,13 @@ function ElasticSearchCall(params, options) {
     self.defaultMethod = options.defaultMethod || 'GET'
     self.auth = options.auth || false
     self.params = params || {}
-
-
+    events.EventEmitter.call(this);
 }
 
-ElasticSearchCall.super_ = events.EventEmitter;
-ElasticSearchCall.prototype = Object.create(events.EventEmitter.prototype, {
-    constructor: {
-        value: ElasticSearchCall,
-        enumerable: false
-    }
-});
+util.inherits(ElasticSearchCall, events.EventEmitter);
 
 ElasticSearchCall.prototype.exec = function() {
-    self = this
+    var self = this
     var reqOptions = {
         path:this.params.path,
         method:this.params.method || this.defaultMethod,


### PR DESCRIPTION
Hi,

the commit log says all:

Fix: a variable scope in ElasticSearchCall.prototype.exec causing wrong listener to be call while doing multiple queries.
Clean: inheritance is now done with util.inherits.
