### PR TITLE
Support for query object in _count

### DIFF
--- a/lib/elasticsearchclient/calls/core.js
+++ b/lib/elasticsearchclient/calls/core.js
@@ -97,17 +97,24 @@ ElasticSearchClient.prototype.percolate = function(indexName, typeName, doc, opt
     return this.createCall({path: path, method: 'GET',data: JSON.stringify(doc)}, this.clientOptions);
 }
 
-//Elastic search takes the query as the body of a get for complex queries. How node httpclient isn't a fan of that it seems
-ElasticSearchClient.prototype.count = function(indexName, typeName, queryStr, options) {
+ElasticSearchClient.prototype.count = function(indexName, typeName, query, options) {
     var path = '/' + indexName + '/' + typeName + '/_count';
-    var qs = '?q='+queryStr;
-    if (options) {
-        qs +='&'+ querystring.stringify(options)
+    
+    switch(typeof query){
+    case 'string':
+	var qs = '?q='+query;
+	if (options) {
+            qs +='&'+ querystring.stringify(options)
+	}	
+	return this.createCall({path: path+qs, method: 'GET'}, this.clientOptions);
+    case 'object':
+	return this.createCall({path : path, method : 'GET', data : JSON.stringify(query)}, this.clientOptions);
     }
 
-    console.log(path+qs);
-    return this.createCall({path: path+qs, method: 'GET'}, this.clientOptions);
-}
+    throw "unsupported query type: " + typeof(query); 
+} 
+
+
 
 ElasticSearchClient.prototype.deleteByQuery = function(indexName, typeName, queryObj, options) {
     var path = '/' + indexName + '/' + typeName + '/_query';


### PR DESCRIPTION
- Add support for query objects in /_count request.

I tested this feature with a few queries, it seems fine.
