### PR TITLE
Creating connection strings with custom path information

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -13,6 +13,7 @@ function ElasticSearchCall(params, options) {
     self.defaultMethod = options.defaultMethod || 'GET'
     self.auth = options.auth || false
     self.params = params || {}
+    self.path = options.path || ''
     events.EventEmitter.call(this);
 }
 
@@ -21,7 +22,7 @@ util.inherits(ElasticSearchCall, events.EventEmitter);
 ElasticSearchCall.prototype.exec = function() {
     var self = this
     var reqOptions = {
-        path:this.params.path,
+        path:this.path + this.params.path,
         method:this.params.method || this.defaultMethod,
         host:this.host,
         port:this.port


### PR DESCRIPTION
Hi There,

I'm not sure if subject is clear but i want to use node-elasticsearch as a client for searchbox.io (saas ElasticSearch). I will promote this client for individual usage and for Heroku.

We are creating connection url's as

```
 http://api.searchbox.io/api-key/1231231.....
```

To fit with that kind of url's i have added a parameter to options object and now we can define a path variable and that is prefixed all request paths.

Old usage remains as is. Additionally now you can;

```
var connectionString = url.parse('http://api.searchbox.io/api-key/123123131231');

var serverOptions = {
    host: connectionString.hostname,
    path: connectionString.pathname
};

var elasticSearchClient = new ElasticSearchClient(serverOptions);

.
.
.
.
```

Could you please review and share your feedback ?

I would be glad if you accept.

Also a deployment to npm would be awesome.

KR,
Ferhat.
