### PR TITLE
Added Content-Length HTTP header to request.

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -63,6 +63,7 @@ ElasticSearchCall.prototype.exec = function() {
             this.params.data = JSON.stringify(this.params.data);
         }
         request.setHeader('Content-Type', 'application/json');
+        request.setHeader('Content-Length', this.params.data.length);
         request.end(this.params.data);
     } else {
         request.end('');


### PR DESCRIPTION
I setup a HTTP proxy to add SSL and basic auth in front of my elastic search instance. This requires a proper Content-Length header for the POST request to exist.

Otherwise it works great!
