### PR TITLE
fixed Content-Length

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -63,7 +63,7 @@ ElasticSearchCall.prototype.exec = function() {
             this.params.data = JSON.stringify(this.params.data);
         }
         request.setHeader('Content-Type', 'application/json');
-        request.setHeader('Content-Length', this.params.data.length);
+        request.setHeader('Content-Length', Buffer.byteLength(this.params.data, 'utf8'));
         request.end(this.params.data);
     } else {
         request.end('');


### PR DESCRIPTION
this.params.data.length returns length in **symbols**, which is not working with non-ascii characters.
Should use Buffer.byteLength to get length in bytes.
