### PR TITLE
add timeout option

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -14,6 +14,7 @@ function ElasticSearchCall(params, options) {
     self.auth = options.auth || false;
     self.params = params || {};
     self.path = [ options.pathPrefix || '', options.path || ''].join('');
+    self.timeout = options.timeout || 1000;
     events.EventEmitter.call(this);
 }
 
@@ -36,6 +37,11 @@ ElasticSearchCall.prototype.exec = function() {
     }
 
     var request = client.request(reqOptions);
+
+    request.setTimeout(self.timeout, function() {
+        self.emit('error', new Error('timed out after ' + self.timeout + 'ms'));
+    });
+
     request.on('error',function(error){
         self.emit("error", error)
     })


### PR DESCRIPTION
This allows you to specify a timeout in milliseconds when creating the elastic search client.
