### PR TITLE
Test for multiget and support for multiget with an array of ids

### DIFF
--- a/lib/elasticsearchclient/calls/core.js
+++ b/lib/elasticsearchclient/calls/core.js
@@ -151,7 +151,11 @@ ElasticSearchClient.prototype.multiget = function(indexName, typeName, documentA
     var data = {docs: []};
 
     for (var i=0; i<objArgs[0].length; i++) {
-        data.docs.push(objArgs[0][i]);
+        var v = objArgs[0][i];
+        if (typeof v !== 'object') {
+            v = {_id: v};
+        }
+        data.docs.push(v);
     }
     return this.createCall({path: path, method: 'GET', data: JSON.stringify(data)}, this.clientOptions, cb);
 }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -96,6 +96,36 @@ describe("ElasticSearchClient Core api", function(){
         });
     });
 
+    describe("#multiget", function(){
+        var check = function(err, data, callback) {
+            data = JSON.parse(data);
+            data.docs.should.exist;
+            data.docs[0]._id.should.equal("sushi");
+            data.docs[0]._source.should.be.ok;
+            callback(err);
+        };
+        it("should fetch the row by id via multiget event style", function(done){
+            elasticSearchClient.multiget(indexName, objName, [ "sushi" ], {})
+            .on('data', function(data) {
+                check(null, data, done);
+            })
+            .on('error', function(err) {
+                done(err);
+            })
+            .exec();
+        });
+        it("should fetch the row by id via multiget canonical", function(done){
+            elasticSearchClient.multiget(indexName, objName, [ "sushi" ] , function(err, data) {
+                check(err, data, done);
+            });
+        });
+        it("should fetch the row by doc via multiget canonical", function(done){
+            elasticSearchClient.multiget(indexName, objName, [{_id: "sushi"}] , function(err, data) {
+                check(err, data, done);
+            });
+        });
+    });
+
     describe("#update", function(){
         it("should update the existing doc by id", function(done){
             elasticSearchClient.update(indexName, objName, "sushi", {doc:{occupation: "play"}})


### PR DESCRIPTION
Add tests for multiget
Tolerate passing into the documents array
the ids of the documents as an alternative to
a document descriptor object.

Thanks for this library, I hope this helps!
