### PR TITLE
Add tests for es#bulk; support index and type

### DIFF
--- a/lib/elasticsearchclient/calls/core.js
+++ b/lib/elasticsearchclient/calls/core.js
@@ -241,18 +241,27 @@ ElasticSearchClient.prototype.count = function(indexName, typeName, query, optio
 
 ElasticSearchClient.prototype.bulk = function(commandArray, options, cb) {
     //Pull the callback and set it false to not clobber id.
-    if(typeof arguments[arguments.length-1]=='function'){
-        cb=arguments[arguments.length-1];
-        arguments[arguments.length-1]=false;
+    if (typeof options === 'function') {
+        cb = options;
+        options = null;
     }
 
     var path = '/_bulk'
     var qs = '';
     if (options) {
+        if (options._index) {
+            if (options._type) {
+                path = '/' + options._index + '/' + options._type + '/_bulk';
+                delete options._type;
+            } else {
+                path = '/' + options._index + '/_bulk';
+            }
+            delete options._index;
+        }
         qs = querystring.stringify(options)
-    }
-    if (qs.length > 0) {
-        path += "?" + qs;
+        if (qs) {
+            path += "?" + qs;
+        }
     }
     var commandBuffer=''
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -262,7 +262,50 @@ describe("ElasticSearchClient Core api", function(){
     });
 
     describe("#bulk", function(){
-        it("should fetch bulk results, not implemented yet");
+        var cmdArr = [
+            {index:{_index:indexName,_type:objName,_id:'bulkedsushi'}},
+            {name:'anothersushi'}
+        ];
+        var cmdArrNoIndexAndNoType = [
+            {index:{_id:'bulkedsushi'}},
+            {name:'anothersushi'}
+        ];
+        var check = function(data, done) {
+            data = JSON.parse(data);
+            data.items.should.be.ok;
+            data.items[0].should.be.ok;
+            data.items[0].index.should.be.ok;
+            done();
+        };
+        it("should index via bulk canonical", function(done) {
+            elasticSearchClient.bulk(cmdArr, function(err,data){
+                check(data,done);
+            });
+        });
+        it("should index via bulk canonical even if options are passed", function(done) {
+            elasticSearchClient.bulk(cmdArr, {}, function(err,data){
+                check(data,done);
+            });
+        });
+        it("should index via bulk event style", function(done) {
+            elasticSearchClient.bulk(cmdArr)
+            .on('data', function(data){
+                check(data,done);
+            })
+            .exec();
+        });
+        it("should index via bulk event style pass index and type via the options", function(done) {
+            elasticSearchClient.bulk(cmdArrNoIndexAndNoType, { _index: indexName, _type: objName})
+            .on('data', function(data){
+                check(data,done);
+            })
+            .exec();
+        });
+        it("should index via bulk canonical pass index and type via the options", function(done) {
+            elasticSearchClient.bulk(cmdArrNoIndexAndNoType, { _index: indexName, _type: objName}, function(err,data){
+                check(data,done);
+            });
+        });
     });
     
     describe("#count", function(){


### PR DESCRIPTION
Extensive tests for the es#bulk operation
Ability to pass use the endpoints /{index}/_bulk,
and {index}/{type}/_bulk by passing those parameters
in the options as _index and _type
Fixed the pulling out of the options arguments
when it is not defined (GH-62)
