### PR TITLE
Support for using a custom http.Agent

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -16,6 +16,7 @@ function ElasticSearchCall(params, options, cb) {
     self.path = [ options.pathPrefix || '', options.path || ''].join('');
     self.timeout = options.timeout || false;
     self.callback = cb || false;
+    self.agent = options.agent;
     events.EventEmitter.call(this);
 }
 
@@ -27,7 +28,8 @@ ElasticSearchCall.prototype.exec = function (cb) {
         path:this.path + this.params.path,
         method:this.params.method || this.defaultMethod,
         host:this.host,
-        port:this.port
+        port:this.port,
+        agent: this.agent
     }
     if (typeof cb == 'function') {
         self.callback = cb;


### PR DESCRIPTION
This adds the support for the option 'agent' to specify an httpAgent to use for the REST calls to ES.

Possible values:
- undefined (default)
- false (no http polling)
- a custom instance of http.Agent

For example one could use this parameter with the
agentkeepalive (https://github.com/TBEDP/agentkeepalive)
to attempt to keep the http connection to ES alive.
