### PR TITLE
Moved _close test to end, and implemented _stats API call

### DIFF
--- a/lib/elasticsearchclient/calls/indices.js
+++ b/lib/elasticsearchclient/calls/indices.js
@@ -366,6 +366,24 @@ ElasticSearchClient.prototype.status = function(indexName, options, cb) {
     return this.createCall({ path:path, method:'GET'}, this.clientOptions, cb);
 }
 
+ElasticSearchClient.prototype.stats = function(indexName, options, cb) {
+    //Pull the callback and set it false to not clobber id.
+    if(arguments.length > 0 && typeof arguments[arguments.length-1]=='function'){
+        cb=arguments[arguments.length-1];
+        arguments[arguments.length-1]=false;
+    }
+
+    var path = indexName ? '/' + indexName + '/_stats' : '/_stats';
+    var qs = '';
+    if (options) {
+        qs = querystring.stringify(options)
+    }
+    if (qs.length > 0) {
+        path += "?" + qs;
+    }
+    return this.createCall({ path:path, method:'GET'}, this.clientOptions, cb);
+}
+
 ElasticSearchClient.prototype.clearCache = function(indexName, options, cb) {
     //Pull the callback and set it false to not clobber id.
     if(arguments.length > 0 && typeof arguments[arguments.length-1]=='function'){

--- a/test/indices.test.js
+++ b/test/indices.test.js
@@ -132,20 +132,6 @@ describe("ElasticSearchClient indices api", function(){
     });
 
 
-    describe("#closeIndex", function(){
-        it("should close the given index", function(done){
-            elasticSearchClient.closeIndex(indexName)
-                .on('data', function(data) {
-                    data = JSON.parse(data);
-                    data.ok.should.be.ok;
-                    data.acknowledged.should.be.ok;
-                    done();
-                })
-                .exec();
-        });
-    });
-
-
     describe("#getSettings", function(){
     	it("should get settings", function(done){
             elasticSearchClient.getSettings(indexName)
@@ -361,6 +347,19 @@ describe("ElasticSearchClient indices api", function(){
     });
 
 
+    describe("#stats", function(){
+        it("should provide stats", function(done){
+            elasticSearchClient.stats(indexName)
+                .on('data', function(data) {
+                    data = JSON.parse(data);
+                    data.ok.should.be.ok;
+                    done();
+                })
+                .exec();
+        });
+    });
+
+
     describe("#clearCache", function(){
     	it("should clear the cache", function(done){
             elasticSearchClient.clearCache(indexName)
@@ -412,6 +411,20 @@ describe("ElasticSearchClient indices api", function(){
                     data = JSON.parse(data);
                     data.should.be.ok;
                     data.indices[indexName].shards.should.be.ok.not.be.empty;
+                    done();
+                })
+                .exec();
+        });
+    });
+
+
+    describe("#closeIndex", function(){
+        it("should close the given index", function(done){
+            elasticSearchClient.closeIndex(indexName)
+                .on('data', function(data) {
+                    data = JSON.parse(data);
+                    data.ok.should.be.ok;
+                    data.acknowledged.should.be.ok;
                     done();
                 })
                 .exec();


### PR DESCRIPTION
Moved fixed _close test to the end so others don't fail on a closed index, and implemented _stats API call + test.

Sorry for the mess - don't think I can push to https://github.com/phillro/node-elasticsearch-client/pull/76 since it shows as merged.

Change-Id: Ibefcf58d732b970f91bc3e999e7600eed3850710
