### PR TITLE
Added generic API calls to create/modify/delete rivers

### DIFF
--- a/lib/elasticsearchclient/calls/river.js
+++ b/lib/elasticsearchclient/calls/river.js
@@ -1,0 +1,27 @@
+var querystring = require('querystring'),
+ElasticSearchClient = require('../elasticSearchClient');
+
+ElasticSearchClient.prototype.deleteRiver = function(riverName, options, cb) {
+    var path = '/_river/'+riverName+'/_meta';
+    var qs = '';
+    if (options) {
+        qs = querystring.stringify(options)
+    }
+    if (qs.length > 0) {
+        path += "?" + qs;
+    }
+    return this.createCall({path:path, method:'DELETE'}, this.clientOptions,cb);
+}
+
+ElasticSearchClient.prototype.createOrModifyRiver = function(riverName, riverData, options, cb) {
+
+    var path = '/_river/'+riverName+'/_meta';
+    var qs = '';
+    if (options) {
+        qs = querystring.stringify(options)
+    }
+    if (qs.length > 0) {
+        path += "?" + qs;
+    }
+    return this.createCall({data:JSON.stringify(riverData),path:path,method: 'PUT'}, this.clientOptions, cb);
+}

--- a/lib/elasticsearchclient/calls/twitter.js
+++ b/lib/elasticsearchclient/calls/twitter.js
@@ -1,27 +1,10 @@
 var querystring = require('querystring'),
 ElasticSearchClient = require('../elasticSearchClient');
 
-ElasticSearchClient.prototype.deleteTwitterRiver = function(riverName, options, cb) {
-    var path = '/_river/'+riverName+'/_meta';
-    var qs = '';
-    if (options) {
-        qs = querystring.stringify(options)
-    }
-    if (qs.length > 0) {
-        path += "?" + qs;
-    }
-    return this.createCall({path:path, method:'DELETE'}, this.clientOptions,cb);
+ElasticSearchClient.prototype.deleteTwitterRiver = function(){
+    return ElasticSearchClient.prototype.deleteRiver.apply(this,arguments);
 }
 
 ElasticSearchClient.prototype.createOrModifyTwitterRiver = function(riverName, riverData, options, cb) {
-
-    var path = '/_river/'+riverName+'/_meta';
-    var qs = '';
-    if (options) {
-        qs = querystring.stringify(options)
-    }
-    if (qs.length > 0) {
-        path += "?" + qs;
-    }
-    return this.createCall({data:JSON.stringify(riverData),path:path,method: 'PUT'}, this.clientOptions, cb);
+    return ElasticSearchClient.prototype.createOrModifyRiver.apply(this,arguments);
 }


### PR DESCRIPTION
Great module, thanks for sharing. 

I need to be able to create and modify rivers programatically and this module looks just right. There are Twitter-specific API calls that seem to do the job (and seem to already be generic) so I've abstracted them into fully generic river calls, and put a wrapper in place so that the Twitter calls still work. Probably quicker to read the diff than my explanation of it.

Let me know if I've misunderstood something or you've got suggested changes.

All the best
