### PR TITLE
Calls to ES throws exception if server not available

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -51,7 +51,11 @@ ElasticSearchCall.prototype.exec = function (cb) {
     }
 
     request.on('error', function (error) {
-        self.emit("error", error)
+        if (typeof self.callback == 'function') {
+            self.callback(error);
+        } else {
+            self.emit("error", error)
+        }
     })
 
     request.on('response', function (response) {


### PR DESCRIPTION
If elasticsearch server is not available or any other network error occurs. callback(error) should be called instead.
