### PR TITLE
Added keep-alive option

### DIFF
--- a/lib/elasticsearchclient/calls/elasticSearchCall.js
+++ b/lib/elasticsearchclient/calls/elasticSearchCall.js
@@ -16,6 +16,7 @@ function ElasticSearchCall(params, options, cb) {
     self.path = [ options.pathPrefix || '', options.path || ''].join('');
     self.timeout = options.timeout || false;
     self.callback = cb || false;
+    self.keepAlive = options.keepAlive || false;
     self.agent = options.agent;
     events.EventEmitter.call(this);
 }
@@ -82,6 +83,10 @@ ElasticSearchCall.prototype.exec = function (cb) {
 
     if (this.auth) {
         request.setHeader("Authorization", "Basic " + new Buffer(this.auth.username + ":" + this.auth.password).toString('base64'))
+    }
+    
+    if (this.keepAlive) {
+    	request.setHeader('Connection', 'keep-alive');
     }
 
     if (this.params.data) {


### PR DESCRIPTION
Sending a 'Connection: keep-alive' will notify Node that the connection
to the server should be persisted until the next request. Can add
significant performance. See
http://nodejs.org/api/http.html#http_http_request_options_callback
